### PR TITLE
Apply satisfaction deltas and fix churn metric

### DIFF
--- a/js/developer.js
+++ b/js/developer.js
@@ -167,6 +167,9 @@ class Developer {
             satisfaction_sum -= this.constants.get("teamSizeImpactOnSatisfaction");
         }
 
+        this.satisfaction += satisfaction_sum;
+        this.burnoutLevel += burnout_sum;
+
         // Clamp values
         this.satisfaction = Math.max(0, Math.min(100, this.satisfaction));
         this.burnoutLevel = Math.max(0, Math.min(100, this.burnoutLevel));

--- a/js/product.js
+++ b/js/product.js
@@ -133,7 +133,7 @@ class Product {
             userCount: Math.round(this.userCount),
             revenue: Math.round(this.revenue),
             reputationThreshold: this.constants.get("reputationThreshold"),
-            churnRate: Math.round(this.churnRate * 100) / 100 // As percentage
+            churnRate: Math.round(this.constants.get("churnRate") * 10000) / 100 // As percentage
         };
     }
     

--- a/tests/simulation.test.js
+++ b/tests/simulation.test.js
@@ -15,7 +15,9 @@ const files = [
 
 const source = `${files.map((file) => fs.readFileSync(file, 'utf8')).join('\n')}
 this.Constants = Constants;
+this.Developer = Developer;
 this.EngineeringTeam = EngineeringTeam;
+this.Product = Product;
 this.Simulation = Simulation;
 `;
 const context = { console };
@@ -72,5 +74,16 @@ teamWithoutLead.addFeatureProject(10);
 teamWithoutLead.step();
 assert.strictEqual(teamWithoutLead.ideaQueue.length, 0);
 assert.strictEqual(teamWithoutLead.todoList.length, 1);
+
+const product = new context.Product(1000, new context.Constants());
+assert.strictEqual(product.getMetrics().churnRate, 0.1);
+assert(!Number.isNaN(product.getMetrics().churnRate));
+
+const developer = new context.Developer('Test Dev', 50, 80, new context.Constants());
+const startingSatisfaction = developer.satisfaction;
+const startingBurnout = developer.burnoutLevel;
+developer.updateSatisfaction({ workload: 1, recentFailures: 1, codebaseQuality: 10, teamSize: 1 });
+assert(developer.satisfaction < startingSatisfaction);
+assert(developer.burnoutLevel > startingBurnout);
 
 console.log('simulation tests passed');


### PR DESCRIPTION
## Summary

Closes #10.
Closes #11.

- Apply accumulated satisfaction and burnout deltas in `Developer.updateSatisfaction`.
- Fix `Product.getMetrics().churnRate` to read from constants instead of undefined instance state.
- Add tests covering non-NaN churn rate and satisfaction/burnout movement.

## Note

#9 is already fixed on current `main`; `reset()` now calls `new Product(1000, this.constants)`.

## Tests

- `npm test` — simulation tests passed