### PR TITLE
chore: add npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "start": "python3 -m http.server 8000",
     "test": "node tests/simulation.test.js"
   }
 }


### PR DESCRIPTION
## Background

- Issue #8 requests a runnable npm path for the static simulation.

## What Has Changed

- Added `npm start` to serve the repo with Python's built-in HTTP server on port 8000.

## Screenshots/Video

- Left for author.

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally

## Reference Issue

- Closes #8