### PR TITLE
test: cover simulation reset smoke

### DIFF
--- a/tests/simulation.test.js
+++ b/tests/simulation.test.js
@@ -75,6 +75,14 @@ teamWithoutLead.step();
 assert.strictEqual(teamWithoutLead.ideaQueue.length, 0);
 assert.strictEqual(teamWithoutLead.todoList.length, 1);
 
+const resetSimulation = new context.Simulation({ seed: 99 });
+resetSimulation.runStep();
+resetSimulation.reset();
+assert.strictEqual(resetSimulation.step, 0);
+resetSimulation.runStep();
+assert.strictEqual(resetSimulation.step, 1);
+assert.strictEqual(resetSimulation.stats.history.length, 1);
+
 const product = new context.Product(1000, new context.Constants());
 assert.strictEqual(product.getMetrics().churnRate, 0.1);
 assert(!Number.isNaN(product.getMetrics().churnRate));


### PR DESCRIPTION
## Background

- Issue #9 reported that reset could leave the simulation in a broken state before the next step.

## What Has Changed

- Added a smoke check for `simulation.reset(); simulation.runStep();`.
- Verifies reset clears the step count and records history after the next step.

## Screenshots/Video

- Left for author.

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally

## Reference Issue

- Closes #9